### PR TITLE
Fix the important attribute for virtual steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ divided by page includes and different controllers you can consider using this a
 </tour>
 ```
 
-Name of the tag doesn't really matter. It's a normal step definition, but the element that will be used to attach to is specified by `virtual-step` attribute.
+Name of the tag doesn't really matter. It's a normal step definition, but the element that will be used to attach to is specified by `tourtip-element` attribute.
 
 ## Customization
 


### PR DESCRIPTION
The README was pointing out that the virtual-step attribute was the important thing to pay attention to in virtual steps configuration, whereas the real name for the attribute is tourtip-element.